### PR TITLE
PEP8 formatting and linting fixes for flake8, bandit, isort, mypy

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,3 @@
+[bandit]
+exclude = */tests/*.py
+tests = B101

--- a/examples/add_installation_metric.py
+++ b/examples/add_installation_metric.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from argparse import ArgumentParser
-from argo_acc_library import ArgoAccountingService
 import sys
+from argparse import ArgumentParser
+
+from argo_acc_library import ArgoAccountingService
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="Simple Argo Accounting metric assignment example")

--- a/examples/get_installation_metrics.py
+++ b/examples/get_installation_metrics.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from argparse import ArgumentParser
-from argo_acc_library import ArgoAccountingService
 import sys
+from argparse import ArgumentParser
+
+from argo_acc_library import ArgoAccountingService
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="Simple Argo Accounting metric fetch example")
@@ -45,7 +46,7 @@ if __name__ == "__main__":
             # print each metric value and type
             print(m.value, m.metric_definition.metric_type)
             # alternatively, print all metric data as JSON string
-            #print(m) 
+            # print(m)
             cnt += 1
         if cnt == 0:
             print("No metrics found for requested installation")

--- a/examples/get_installations.py
+++ b/examples/get_installations.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from argparse import ArgumentParser
-from argo_acc_library import ArgoAccountingService
 import sys
+from argparse import ArgumentParser
+
+from argo_acc_library import ArgoAccountingService
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="Simple Argo Accounting metric fetch example")

--- a/examples/get_project_metrics.py
+++ b/examples/get_project_metrics.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from argparse import ArgumentParser
-from argo_acc_library import ArgoAccountingService
 import sys
+from argparse import ArgumentParser
+
+from argo_acc_library import ArgoAccountingService
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="Simple Argo Accounting metric fetch example")
@@ -45,7 +46,7 @@ if __name__ == "__main__":
             # print each metric value and type
             print(m.value, m.metric_definition.metric_type)
             # alternatively, print all metric data as JSON string
-            # print(m) 
+            # print(m)
             cnt += 1
         if cnt == 0:
             print("No metrics found for requested project")

--- a/examples/get_projects.py
+++ b/examples/get_projects.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from argparse import ArgumentParser
-from argo_acc_library import ArgoAccountingService
 import sys
+from argparse import ArgumentParser
+
+from argo_acc_library import ArgoAccountingService
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="Simple Argo Accounting metric fetch example")

--- a/examples/get_provider_metrics.py
+++ b/examples/get_provider_metrics.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from argparse import ArgumentParser
-from argo_acc_library import ArgoAccountingService
 import sys
+from argparse import ArgumentParser
+
+from argo_acc_library import ArgoAccountingService
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="Simple Argo Accounting metric fetch example")
@@ -51,7 +52,7 @@ if __name__ == "__main__":
             # print each metric value and type
             print(m.value, m.metric_definition.metric_type)
             # alternatively, print all metric data as JSON string
-            # print(m) 
+            # print(m)
             cnt += 1
         if cnt == 0:
             print("No metrics found for requested provider / project combination")

--- a/examples/get_providers.py
+++ b/examples/get_providers.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from argparse import ArgumentParser
-from argo_acc_library import ArgoAccountingService
 import sys
+from argparse import ArgumentParser
+
+from argo_acc_library import ArgoAccountingService
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="Simple Argo Accounting metric fetch example")

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+
+[mypy-httmock]
+follow_untyped_imports = true

--- a/pymod/__init__.py
+++ b/pymod/__init__.py
@@ -1,17 +1,11 @@
 import logging
 import os
 
-try:
-    from logging import NullHandler
-except ImportError:
-
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
+from .argoaccountingservice import ArgoAccountingService
+from .metrics import InstallationMetric
 
 logger = logging.getLogger(__name__)
-if os.getenv("DEBUG") is not None and os.getenv("DEBUG").lower() in [
+if os.getenv("DEBUG") is not None and str(os.getenv("DEBUG")).lower() in [
     "1",
     "t",
     "true",
@@ -29,24 +23,22 @@ if os.getenv("DEBUG") is not None and os.getenv("DEBUG").lower() in [
     logger.addHandler(ch)
     logger.setLevel(logging.DEBUG)
 else:
-    logger.addHandler(NullHandler())
+    logger.addHandler(logging.NullHandler())
 
-from .exceptions import (
-    AccException,
-    AccServiceException,
-    AccTimeoutException,
-    AccConnectionException,
-)
-from .argoaccountingservice import (
-    ArgoAccountingService,
-    Installations,
-    Installation,
-    InstallationMetrics,
-    InstallationMetric,
-    Projects,
-    Project,
-    ProjectMetrics,
-    ProjectMetric,
-    Providers,
-    Provider,
-)
+__all__ = [
+    "ArgoAccountingService",
+    "Installation",
+    "InstallationMetric",
+    "InstallationMetrics",
+    "Installations",
+    "Project",
+    "ProjectMetric",
+    "ProjectMetrics",
+    "Projects",
+    "Provider",
+    "Providers",
+    "AccConnectionException",
+    "AccException",
+    "AccServiceException",
+    "AccTimeoutException"
+]

--- a/pymod/argoaccountingservice.py
+++ b/pymod/argoaccountingservice.py
@@ -1,28 +1,20 @@
-from .httprequests import HttpRequests
-from .installations import Installations, Installation
-from .projects import Projects, Project
-from .providers import Providers, Provider
-from .metrics import (
-    InstallationMetric,
-    InstallationMetrics,
-    ProjectMetric,
-    ProjectMetrics,
-    ProviderMetrics,
-    ProviderMetric,
-)
 from typing import Optional
+
+from .httprequests import HttpRequests
+from .installations import Installations
+from .projects import Projects
+from .providers import Providers
 
 
 class ArgoAccountingService(object):
     """Module main class, to access the REST API"""
 
-    _installations: Optional[Installations] = None
-    _projects: Optional[Projects] = None
-    _providers: Optional[Providers] = None
-
     def __init__(self, endpoint, token):
         self._endpoint = endpoint
         self._conn = HttpRequests(token)
+        self._installations: Optional[Installations] = None
+        self._projects: Optional[Projects] = None
+        self._providers: Optional[Providers] = None
 
     @property
     def installations(self):

--- a/pymod/httprequests.py
+++ b/pymod/httprequests.py
@@ -1,10 +1,11 @@
-import requests
-import sys
+import json
 import logging
 import socket
-import json
 
-from .exceptions import AccConnectionException, AccServiceException, AccTimeoutException
+import requests
+
+from .exceptions import (AccConnectionException, AccServiceException,
+                         AccTimeoutException)
 
 logger = logging.getLogger(__name__)
 

--- a/pymod/installations.py
+++ b/pymod/installations.py
@@ -1,20 +1,28 @@
-from .restresource import RestResourceList, RestResourceItem
 from .metrics import InstallationMetrics
+from .restresource import RestResourceItem, RestResourceList
+
 
 class InstallationBase(RestResourceItem):
-    id = None
-    project = None
-    organisation = None
-    infrastructure = None
-    installation = None
-    resource = None
-    unit_of_access = None
+    """Base class for Installation related classes"""
+
+    def __init__(self, parent, data: dict):
+        self.id = None
+        self.project = None
+        self.organisation = None
+        self.infrastructure = None
+        self.installation = None
+        self.resource = None
+        self.unit_of_access = None
+        super().__init__(parent, data)
+
 
 class Installation(InstallationBase):
-    def _fetchRoute(self):
+    """Class to represent an installation"""
+
+    def _fetch_route(self):
         return "installation_entry"
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return [self.id]
 
     @property
@@ -23,21 +31,24 @@ class Installation(InstallationBase):
 
 
 class Installations(RestResourceList):
-    def _fetchRoute(self):
+    """Installation collection class"""
+    def _fetch_route(self):
         return "installation_list"
 
-    def _fetchArgs(self) -> list:
+    def _fetch_args(self) -> list:
         return []
 
-    def _createChild(self, data):
+    def _create_child(self, data):
         return Installation(self, data)
 
 
 class ProjectInstallation(InstallationBase):
-    def _fetchRoute(self):
+    """Class to represent an installation belonging to a project"""
+
+    def _fetch_route(self):
         return ""
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return []
 
     @property
@@ -46,20 +57,25 @@ class ProjectInstallation(InstallationBase):
 
 
 class ProjectInstallations(RestResourceList):
-    def _fetchRoute(self):
+    """Project installation collection class"""
+
+    def _fetch_route(self):
         return "project_installations_list"
 
-    def _fetchArgs(self) -> list:
+    def _fetch_args(self) -> list:
         return [self._parent.id]
 
-    def _createChild(self, data):
+    def _create_child(self, data):
         return ProjectInstallation(self, data)
 
+
 class ProjectProviderInstallation(InstallationBase):
-    def _fetchRoute(self):
+    """Class to represent an installation belonging to a project for a specific provider"""
+
+    def _fetch_route(self):
         return ""
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return []
 
     @property
@@ -68,11 +84,13 @@ class ProjectProviderInstallation(InstallationBase):
 
 
 class ProjectProviderInstallations(RestResourceList):
-    def _fetchRoute(self):
+    """Project provider installation collection class"""
+
+    def _fetch_route(self):
         return "project_provider_installations_list"
 
-    def _fetchArgs(self) -> list:
+    def _fetch_args(self) -> list:
         return [self._parent._parent._parent.id, self._parent.id]
 
-    def _createChild(self, data):
+    def _create_child(self, data):
         return ProjectProviderInstallation(self, data)

--- a/pymod/metrics.py
+++ b/pymod/metrics.py
@@ -1,105 +1,120 @@
-from .restresource import RestResourceList, RestResourceItem
+from .restresource import RestResourceItem, RestResourceList
 
 
 class MetricBase(RestResourceItem):
-    id = None
-    time_period_start = None
-    time_period_end = None
-    value = None
-    project = None
-    provider = None
-    installation_id = None
-    project_id = None
-    resource = None
-    group_id = None
-    user_id = None
-    metric_definition_id = None
+    """Base class for metric related classes"""
 
     def __init__(self, parent, data: dict):
+        self.id = None
+        self.time_period_start = None
+        self.time_period_end = None
+        self.value = None
+        self.project = None
+        self.provider = None
+        self.installation_id = None
+        self.project_id = None
+        self.resource = None
+        self.group_id = None
+        self.user_id = None
+        self.metric_definition_id = None
         super().__init__(parent, data)
         if data.get("metric_definition"):
             self.metric_definition = MetricDefinition(self, data["metric_definition"])
 
 
 class MetricDefinition(RestResourceItem):
-    metric_definition_id = None
-    metric_name = None
-    metric_description = None
-    unit_type = None
-    metric_type = None
-    creator_id = None
+    """Class to represent a metric definition"""
 
-    def _fetchRoute(self):
+    def __init__(self, parent, data: dict):
+        self.metric_definition_id = None
+        self.metric_name = None
+        self.metric_description = None
+        self.unit_type = None
+        self.metric_type = None
+        self.creator_id = None
+        super().__init__(parent, data)
+
+    def _fetch_route(self):
         return ""
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return []
 
 
 class Metrics(RestResourceList):
-    """Base class for all metrics related subclasses"""
+    """Base class for all metric collection subclasses"""
 
     pass
 
 
 class InstallationMetric(MetricBase):
-    def _fetchRoute(self):
+    """Class to represent a metric for a specific installation"""
+
+    def _fetch_route(self):
         return "installation_metrics_entry"
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return [self._parent._parent.id, self.id]
 
 
 class InstallationMetrics(Metrics):
-    def _fetchRoute(self):
+    """Installation metrics collection class"""
+
+    def _fetch_route(self):
         return "installation_metrics_list"
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return [self._parent.id]
 
-    def _addRoute(self):
+    def _add_route(self):
         return "installation_metrics_add"
 
-    def _addArgs(self):
+    def _add_args(self):
         return [self._parent.id]
 
-    def _createChild(self, data):
+    def _create_child(self, data):
         return InstallationMetric(self, data)
 
 
 class ProjectMetric(MetricBase):
-    def _fetchRoute(self):
+    """Class to represent a metric for a specific project"""
+
+    def _fetch_route(self):
         return ""
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return []
 
 
 class ProjectMetrics(Metrics):
-    def _fetchRoute(self):
+    """Project metrics collection class"""
+
+    def _fetch_route(self):
         return "project_metrics_list"
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return [self._parent.id]
 
-    def _createChild(self, data):
+    def _create_child(self, data):
         return ProjectMetric(self, data)
 
 
 class ProviderMetric(MetricBase):
-    def _fetchRoute(self):
+    """Class to represent a metric for a specific provider"""
+    def _fetch_route(self):
         return ""
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return []
 
 
 class ProviderMetrics(Metrics):
-    def _fetchRoute(self):
+    """Project metrics collection class"""
+    def _fetch_route(self):
         return "project_provider_metric_list"
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return [self._parent._parent._parent.id, self._parent.id]
 
-    def _createChild(self, data):
+    def _create_child(self, data):
         return ProviderMetric(self, data)

--- a/pymod/projects.py
+++ b/pymod/projects.py
@@ -1,22 +1,26 @@
-from .restresource import RestResourceList, RestResourceItem
-from .metrics import ProjectMetrics
 from .installations import ProjectInstallations
+from .metrics import ProjectMetrics
 from .providers import ProjectProviders
+from .restresource import RestResourceItem, RestResourceList
 
 
 class Project(RestResourceItem):
-    id = None
-    acronym = None
-    title = None
-    start_date = None
-    end_date = None
-    call_identifier = None
-    _providers = None
+    """Class to represent projects"""
 
-    def _fetchRoute(self):
+    def __init__(self, parent, data: dict):
+        self.id = None
+        self.acronym = None
+        self.title = None
+        self.start_date = None
+        self.end_date = None
+        self.call_identifier = None
+        self._providers = None
+        super().__init__(parent, data)
+
+    def _fetch_route(self):
         return "project_entry"
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return [self.id]
 
     @property
@@ -37,11 +41,13 @@ class Project(RestResourceItem):
 
 
 class Projects(RestResourceList):
-    def _fetchRoute(self):
+    """Project collection class"""
+
+    def _fetch_route(self):
         return "project_list"
 
-    def _fetchArgs(self) -> list:
+    def _fetch_args(self) -> list:
         return []
 
-    def _createChild(self, data):
+    def _create_child(self, data):
         return Project(self, data)

--- a/pymod/providers.py
+++ b/pymod/providers.py
@@ -1,21 +1,25 @@
-from .restresource import RestResourceList, RestResourceItem
-from .metrics import ProviderMetrics
 from .installations import ProjectProviderInstallations
+from .metrics import ProviderMetrics
+from .restresource import RestResourceItem, RestResourceList
 
 
 class Provider(RestResourceItem):
-    id = None
-    acronym = None
-    title = None
-    start_date = None
-    end_date = None
-    call_identifier = None
-    providers = None
+    """Class to represent providers"""
 
-    def _fetchRoute(self):
+    def __init__(self, parent, data: dict):
+        self.id = None
+        self.acronym = None
+        self.title = None
+        self.start_date = None
+        self.end_date = None
+        self.call_identifier = None
+        self.providers = None
+        super().__init__(parent, data)
+
+    def _fetch_route(self):
         return "provider_entry"
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return [self.id]
 
     @property
@@ -24,21 +28,25 @@ class Provider(RestResourceItem):
 
 
 class Providers(RestResourceList):
-    def _fetchRoute(self):
+    """Provider collection class"""
+
+    def _fetch_route(self):
         return "provider_list"
 
-    def _fetchArgs(self) -> list:
+    def _fetch_args(self) -> list:
         return []
 
-    def _createChild(self, data):
+    def _create_child(self, data):
         return Provider(self, data)
 
 
 class ProjectProvider(RestResourceItem):
-    def _fetchRoute(self):
+    """Class to represent a provider under the context of a specific project"""
+
+    def _fetch_route(self):
         return ""
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return []
 
     @property
@@ -49,11 +57,14 @@ class ProjectProvider(RestResourceItem):
     def installations(self):
         return ProjectProviderInstallations(self)
 
+
 class ProjectProviders(RestResourceList):
-    def _fetchRoute(self):
+    """Project providers collection class"""
+
+    def _fetch_route(self):
         return ""
 
-    def _fetchArgs(self):
+    def _fetch_args(self):
         return []
 
     def __getitem__(self, key: str):

--- a/pymod/restresource.py
+++ b/pymod/restresource.py
@@ -1,8 +1,7 @@
-from collections import OrderedDict
-import json
 import abc
-from time import sleep
+import json
 import logging
+from collections import OrderedDict
 from typing import Union
 
 logger = logging.getLogger(__name__)
@@ -15,7 +14,7 @@ class RestResource(abc.ABC):
         """Initialize a REST response
 
         Args:
-            parent(oject): an ArgoAccountingService object or another RestResource instance
+            parent(oject): an ArgoMonitoringService object or another RestResource instance
         """
         self._parent = parent
 
@@ -28,15 +27,24 @@ class RestResource(abc.ABC):
         return self._parent.connection
 
     @property
-    def idName(self):
-        """Return the JSON field name that identifies the resource. Defaults to "id", subclasses may need to override it"""
+    def id_name(self):
+        """
+        Return the JSON field name that identifies the resource.
+        Defaults to "id", subclasses may need to override it
+        """
         return "id"
+
+    @property
+    def data_root(self):
+        """
+        Return the JSON field name that contains the resource data.
+        Defaults to None, which treats the whole of the JSON resource as data
+        """
+        return None
 
 
 class RestResourceItem(RestResource):
     """Base class for REST API responses representing a single item"""
-
-    id = None
 
     def __init__(self, parent, data: dict):
         """
@@ -46,9 +54,13 @@ class RestResourceItem(RestResource):
         """
         logger.debug("Initing RestResourceItem object " + str(type(self)))
         self._parent = parent
+        self.id = None
         if len(data) == 1 and data.get("__fetch__") is not None:
             self.id = data["__fetch__"]
-            data = self._fetch()
+            if self.data_root is None:
+                data = self._fetch()
+            else:
+                data = self._fetch()[self.data_root][0]
         for k in data:
             # logger.debug("setting " + k + " to " + (str(data[k]) or "<None>"))
             setattr(self, k, data[k])
@@ -62,6 +74,20 @@ class RestResourceItem(RestResource):
             if not isinstance(self.__dict__[x], RestResource)
             and x not in {"_parent", "parent"}
         }
+        while True:
+            changed = False
+            for k, v in d1.items():
+                if k.startswith("__"):
+                    del d1[k]
+                    changed = True
+                    break
+                if k.startswith("_"):
+                    d1[k[1:]] = v
+                    del d1[k]
+                    changed = True
+                    break
+            if not changed:
+                break
         # Loop over properties that are RestResource instances (excluding "_parent")
         # and append their properties to the dictionary
         for x in self.__dict__:
@@ -70,10 +96,10 @@ class RestResourceItem(RestResource):
                 del d2["_parent"]
                 d1 = {**d1, x: d2}
         # Return a JSON representation of the built dictionary
-        return json.dumps(d1)
+        return json.dumps(d1, default=str)
 
     @abc.abstractmethod
-    def _fetchRoute(self) -> str:
+    def _fetch_route(self) -> str:
         """Abstract method to be implemented by subclasses, to denote the REST API route for GET requests
 
         Should return the key from the parent service object route dict, that corresponds to the REST route
@@ -81,18 +107,18 @@ class RestResourceItem(RestResource):
         return ""
 
     @abc.abstractmethod
-    def _fetchArgs(self) -> list:
+    def _fetch_args(self) -> list:
         """Abstract method to be implemented by subcasses, to provide values for params on the GET REST route"""
         return []
 
     def _fetch(self):
-        """Fetch an entry from the REST API, using the fetch route denoted by self::_fetchRoute"""
+        """Fetch an entry from the REST API, using the fetch route denoted by self::_fetch_route"""
         logger.debug("FETCHING ITEM")
         res = self.connection.make_request(
-            self.connection.routes[self._fetchRoute()][1].format(
-                self.endpoint, *self._fetchArgs()
+            self.connection.routes[self._fetch_route()][1].format(
+                self.endpoint, *self._fetch_args()
             ),
-            self._fetchRoute(),
+            self._fetch_route()
         )
         return res
 
@@ -101,45 +127,41 @@ class RestResourceList(OrderedDict, RestResource):
     """
     Base class for REST API responses representing a paged list of items.
 
-    Inherits OrderedDict to keep an internal dict of RestResourceItems when iterrating, and a separate cache dict to avoid
-    re-fetching individual items.
+    Inherits OrderedDict to keep an internal dict of RestResourceItems when iterrating,
+    and a separate cache dict to avoid re-fetching individual items.
     """
 
-    _pageSize = 10
-    _pageCount = 1
-    _currentPage = 0
-    _cache = OrderedDict()
-
-    def __init__(self, parent, pageSize=10):
+    def __init__(self, parent, page_size=10):
         logger.debug("Initing RestResourceList object " + str(type(self)))
         super(OrderedDict, self).__init__()
         super(RestResource, self).__init__()
         self._parent = parent
-        self._pageSize = pageSize
+        self._page_size = page_size
+        self._page_count = 1
+        self._current_page = 0
+        self._cache = OrderedDict()
 
     def refresh(self):
         """Clear the internal dict, the cache dict, and reset paging"""
         self.clear()
         self._cache.clear()
-        self._currentPage = 0
-        self._pageCount = 1
+        self._current_page = 0
+        self._page_count = 1
         return self
 
-    @abc.abstractmethod
-    def _addRoute(self) -> str:
+    def _add_route(self) -> str:
         """Abstract method to be implemented by subclasses, to denote the REST API route for POST requests
 
         Should return the key from the parent service object route dict, that corresponds to the REST route
         """
-        return ""
+        raise Exception("Operation not supported or not implemented")
 
-    @abc.abstractmethod
-    def _addArgs(self) -> list:
+    def _add_args(self) -> list:
         """Abstract method to be implemented by subcasses, to provide values for params on the POST REST route"""
-        return []
+        raise Exception("Operation not supported or not implemented")
 
     @abc.abstractmethod
-    def _fetchRoute(self) -> str:
+    def _fetch_route(self) -> str:
         """Abstract method to be implemented by subcasses, to denote the REST API route for GET requests
 
         Should return the key from the parent service object route dict, that corresponds to the REST route
@@ -147,62 +169,54 @@ class RestResourceList(OrderedDict, RestResource):
         return ""
 
     @abc.abstractmethod
-    def _fetchArgs(self) -> list:
+    def _fetch_args(self) -> list:
         """Abstract method to be implemented by subcasses, to provide values for params on the GET REST route"""
         return []
 
-    @abc.abstractmethod
-    def _createChild(self, data: dict):
+    def _create_child(self, data: dict):
         """Abstract method to be implemented by subclasses, to create the appropriate RestResourceItem instance"""
-        return RestResourceItem(self, {})
+        raise Exception("Operation not supported or not implemented")
 
     def _fetch(self):
-        """Fetch a page of results from the REST API, using the fetch route denoted by self::_fetchRoute
+        """
+        Fetch results from the REST API, using the fetch route denoted by self::_fetch_route
 
-        Will fetch up to self::_pageSize results each time, keeping track of the current page of results in self::_currentPage
+        Will fetch up to self::_page_size results each time, keeping track of the current page
+        of results in self::_current_page
         """
         logger.debug("FETCHING LIST")
         res = self.connection.make_request(
-            self.connection.routes[self._fetchRoute()][1].format(
-                self.endpoint, *self._fetchArgs()
+            self.connection.routes[self._fetch_route()][1].format(
+                self.endpoint, *self._fetch_args()
             ),
-            self._fetchRoute(),
-            params={"page": self._currentPage + 1},
+            self._fetch_route(),
+            params={"page": self._current_page + 1},
         )
-        self._pageCount = res["total_pages"]
+        self._page_count = res["total_pages"]
         # Create a RestResourceItem for each JSON object in the response, and add it to the internal dict
-        for i in res["content"]:
-            self.update({i[self.idName]: self._createChild(i)})
-        self._currentPage += 1
+        if self.data_root is None:
+            data_root = res["content"]
+        else:
+            data_root = res[self.data_root]
+        for i in data_root:
+            self.update({i[self.id_name]: self._create_child(i)})
+        self._current_page += 1
 
     def __iter__(self):
         """Iterate over all results, using self::_fetch for each page"""
         logger.debug("ITERING")
-        while self._currentPage < self._pageCount:
+        while self._current_page < self._page_count:
             self._fetch()
             logger.debug(
-                "PAGE " + str(self._currentPage) + " of " + str(self._pageCount)
+                "PAGE " + str(self._current_page) + " of " + str(self._page_count)
             )
-            for i, j in enumerate(self.items()):
-                if i >= (self._currentPage - 1) * self._pageSize:
-                    yield j[1]
+            if len(self.items()) == 0:
+                return None
+            else:
+                for i, j in enumerate(self.items()):
+                    if i >= (self._current_page - 1) * self._page_size:
+                        yield j[1]
         logger.debug("EOD")
-
-    def _iterN(self, n: int):
-        """
-        Iterate up to the n-th result, using self::_fetch for each page.
-        Used by __getitem__ to avoid fetching everying, when asking for an item by index instead of ID
-        """
-        logger.debug("ITERING up to " + str(n))
-        while self._currentPage * self._pageSize <= n:
-            self._fetch()
-            logger.debug(
-                "PAGE " + str(self._currentPage) + " of " + str(self._pageCount)
-            )
-            for i, j in enumerate(self.items()):
-                if i >= (self._currentPage - 1) * self._pageSize:
-                    yield j[1]
-        logger.debug("EOD(" + str(n) + ")")
 
     def __getitem__(self, id):
         """
@@ -213,19 +227,27 @@ class RestResourceList(OrderedDict, RestResource):
         upon success
         """
         if isinstance(id, int):
-            item = list(self._iterN(id))[id]
+            item = None
+            i = 0
+            for it in self:
+                if i == id:
+                    item = it
+                    break
+                i += 1
         else:
             item = super(OrderedDict, self).get(id)
             if item is None:
                 item = self._cache.get(id)
                 if item is None:
-                    item = self._createChild({"__fetch__": id})
+                    item = self._create_child({"__fetch__": id})
                     if item is not None:
-                        self._cache.update({getattr(item, self.idName): item})
+                        self._cache.update({getattr(item, self.id_name): item})
         return item
 
     def get(self, id, default=None):
-        """OrderedDict get override. Calls __getitem__ but ignores errors and returns default value on failures, instead"""
+        """
+        OrderedDict get override. Calls __getitem__ but ignores errors and returns default value on failures, instead
+        """
         tmp = None
         try:
             tmp = self.__getitem__(id)
@@ -236,10 +258,11 @@ class RestResourceList(OrderedDict, RestResource):
         """
         Creates a new subresource under the resource list
 
-        This will issue an API request using the endpoint specified by the _addRoute property, posting a JSON representation of the given item.
-        If the request succeedes, the appropriate RestResourceItem subclassed object will be returned, populated with the response's data
+        This will issue an API request using the endpoint specified by the _add_route property,
+        posting a JSON representation of the given item. If the request succeedes, the appropriate
+        RestResourceItem subclassed object will be returned, populated with the response's data
         """
-        if self._addRoute != "":
+        if self._add_route != "":
             if isinstance(item, RestResourceItem):
                 body = str(item)
             elif isinstance(item, dict):
@@ -247,13 +270,16 @@ class RestResourceList(OrderedDict, RestResource):
             else:
                 body = item
             res = self.connection.make_request(
-                self.connection.routes[self._addRoute()][1].format(
-                    self.endpoint, *self._addArgs()
+                self.connection.routes[self._add_route()][1].format(
+                    self.endpoint, *self._add_args()
                 ),
-                self._addRoute(),
+                self._add_route(),
                 body=body,
             )
-            ret = self._createChild(res)
+            ret = self._create_child(res)
             return ret
         else:
             raise Exception("Operation not supported or not implemented")
+
+    def __str__(self):
+        return "[{0}]".format(", ".join([str(x) for x in list(self)]))

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-from setuptools import setup
 from os import path
-import sys
+
+from setuptools import setup
 
 NAME = 'argo-acc-library'
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,17 +1,15 @@
 import logging
 import os
 
-try:
-    from logging import NullHandler
-except ImportError:
-
-    class NullHandler(logging.Handler):
-        def emit(self, record):
-            pass
-
-
 logger = logging.getLogger(__name__)
-if os.getenv("DEBUG"):
+logger = logging.getLogger(__name__)
+if os.getenv("DEBUG") is not None and str(os.getenv("DEBUG")).lower() in [
+    "1",
+    "t",
+    "true",
+    "y",
+    "yes",
+]:
     import sys
 
     ch = logging.StreamHandler(sys.stderr)
@@ -23,4 +21,4 @@ if os.getenv("DEBUG"):
     logger.addHandler(ch)
     logger.setLevel(logging.DEBUG)
 else:
-    logger.addHandler(NullHandler())
+    logger.addHandler(logging.NullHandler())

--- a/tests/accmocks.py
+++ b/tests/accmocks.py
@@ -1,10 +1,19 @@
-from httmock import urlmatch, response
 import json
 
-class ProviderMocks(object):
-    LIST_PROVIDERS_RESPONSE = """{"size_of_page":1,"number_of_page":1,"total_elements":1,"total_pages":1,"content":[{"id":"TESTPROV01","name":"TEST PROVIDER 01","website":"https://example.org","abbreviation":"TESTPROV01","logo":"https://example.org","creator_id":"0123456789abcdef"}], "links": []}"""
+from httmock import response, urlmatch
 
-    GET_PROVIDER_TEST_RESPONSE = """{"id":"TESTPROV01","name":"TEST PROVIDER 01","website":"https://example.org","abbreviation":"TESTPROV01","logo":"https://example.org","creator_id":"0123456789abcdef"}"""
+
+class ProviderMocks(object):
+    LIST_PROVIDERS_RESPONSE = (
+        """{"size_of_page":1,"number_of_page":1,"total_elements":1,"total_pages":1,"content":[{"id":"TESTPROV01","""
+        """"name":"TEST PROVIDER 01","website":"https://example.org","abbreviation":"TESTPROV01","logo":"""
+        """"https://example.org","creator_id":"0123456789abcdef"}], "links": []}"""
+    )
+
+    GET_PROVIDER_TEST_RESPONSE = (
+        """{"id":"TESTPROV01","name":"TEST PROVIDER 01","website":"https://example.org","abbreviation":"TESTPROV01","""
+        """"logo":"https://example.org","creator_id":"0123456789abcdef"}"""
+    )
 
     list_providers_urlmatch = dict(
         netloc="localhost",
@@ -35,9 +44,23 @@ class ProviderMocks(object):
 
 
 class ProjectMocks(object):
-    LIST_PROJECTS_RESPONSE = """{"size_of_page":1,"number_of_page":1,"total_elements":1,"total_pages":1,"content":[{"id": "TESTPROJ01", "acronym": "TestProj01", "title": "TEST PROJECT 01", "start_date": "2024-04-01", "end_date": "2027-03-31", "call_identifier": "TESTCALL01", "providers": [{"id": "TESTPROV01", "name": "Test Provider 01", "website": "https://example.org", "abbreviation": "testprov01", "logo": "https://example.com", "installations": [{"id": "68179546f1a5b48f0c854353", "infrastructure": "TESTINFRA01", "installation": "TESTINSTA01", "resource": "TESTRES01", "unit_of_access": null}]}]}], "links": []}"""
+    LIST_PROJECTS_RESPONSE = (
+        """{"size_of_page":1,"number_of_page":1,"total_elements":1,"total_pages":1,"content":[{"id": "TESTPROJ01","""
+        """ "acronym": "TestProj01", "title": "TEST PROJECT 01", "start_date": "2024-04-01", "end_date":"""
+        """ "2027-03-31", "call_identifier": "TESTCALL01", "providers": [{"id": "TESTPROV01", "name":"""
+        """ "Test Provider 01", "website": "https://example.org", "abbreviation": "testprov01", "logo":"""
+        """ "https://example.com", "installations": [{"id": "68179546f1a5b48f0c854353", "infrastructure":"""
+        """ "TESTINFRA01", "installation": "TESTINSTA01", "resource": "TESTRES01", "unit_of_access": null}]}]}],"""
+        """ "links": []}"""
+    )
 
-    GET_PROJECT_TEST_RESPONSE = """{"id": "TESTPROJ01", "acronym": "TestProj01", "title": "TEST PROJECT 01", "start_date": "2024-04-01", "end_date": "2027-03-31", "call_identifier": "TESTCALL01", "providers": [{"id": "TESTPROV01", "name": "Test Provider 01", "website": "https://example.org", "abbreviation": "testprov01", "logo": "https://example.com", "installations": [{"id": "68179546f1a5b48f0c854353", "infrastructure": "TESTINFRA01", "installation": "TESTINSTA01", "resource": "TESTRES01", "unit_of_access": null}]}]}"""
+    GET_PROJECT_TEST_RESPONSE = (
+        """{"id": "TESTPROJ01", "acronym": "TestProj01", "title": "TEST PROJECT 01", "start_date": "2024-04-01","""
+        """ "end_date": "2027-03-31", "call_identifier": "TESTCALL01", "providers": [{"id": "TESTPROV01", "name":"""
+        """ "Test Provider 01", "website": "https://example.org", "abbreviation": "testprov01", "logo":"""
+        """ "https://example.com", "installations": [{"id": "68179546f1a5b48f0c854353", "infrastructure":"""
+        """ "TESTINFRA01", "installation": "TESTINSTA01", "resource": "TESTRES01", "unit_of_access": null}]}]}"""
+    )
 
     list_projects_urlmatch = dict(
         netloc="localhost",
@@ -68,23 +91,44 @@ class ProjectMocks(object):
 
 
 class InstallationMocks(object):
-    LIST_INSTALLATIONS_RESPONSE1 = """{"size_of_page":10,"number_of_page":1,"total_elements":12,"total_pages":2,"content":[
-        {"id":"68179546f1a5b48f0c854353","project":"TESTPROJ01","organisation":"TESTORG01","infrastructure":"TESTINFRA01","installation":"TESTINSTA01","resource":"TESTRES01","unit_of_access":null},
-        {"id":"681795464c2922e4367fe1c4","project":"TESTPROJ02","organisation":"TESTORG02","infrastructure":"TESTINFRA02","installation":"TESTINSTA02","resource":"TESTRES02","unit_of_access":null},
-        {"id":"681795463c792bf6c23aa741","project":"TESTPROJ03","organisation":"TESTORG03","infrastructure":"TESTINFRA03","installation":"TESTINSTA03","resource":"TESTRES03","unit_of_access":null},
-        {"id":"681795463ae9de407c8073da","project":"TESTPROJ04","organisation":"TESTORG04","infrastructure":"TESTINFRA04","installation":"TESTINSTA04","resource":"TESTRES04","unit_of_access":null},
-        {"id":"681795460e9b55f38d982f77","project":"TESTPROJ05","organisation":"TESTORG05","infrastructure":"TESTINFRA05","installation":"TESTINSTA05","resource":"TESTRES05","unit_of_access":null},
-        {"id":"681795468c189cee4e182e7e","project":"TESTPROJ06","organisation":"TESTORG06","infrastructure":"TESTINFRA06","installation":"TESTINSTA06","resource":"TESTRES06","unit_of_access":null},
-        {"id":"68179546dce2f040d31e0129","project":"TESTPROJ07","organisation":"TESTORG07","infrastructure":"TESTINFRA07","installation":"TESTINSTA07","resource":"TESTRES07","unit_of_access":null},
-        {"id":"68179546e21a7a5849d09fb3","project":"TESTPROJ08","organisation":"TESTORG08","infrastructure":"TESTINFRA08","installation":"TESTINSTA08","resource":"TESTRES08","unit_of_access":null},
-        {"id":"68179546f9116f197e3df2a0","project":"TESTPROJ09","organisation":"TESTORG09","infrastructure":"TESTINFRA09","installation":"TESTINSTA09","resource":"TESTRES09","unit_of_access":null},
-        {"id":"68179546680552ca72c5c4bb","project":"TESTPROJ10","organisation":"TESTORG10","infrastructure":"TESTINFRA10","installation":"TESTINSTA10","resource":"TESTRES10","unit_of_access":null}
-    ],"links":[]}"""
-    LIST_INSTALLATIONS_RESPONSE2 = """{"size_of_page":10,"number_of_page":2,"total_elements":12,"total_pages":2,"content":[
-        {"id":"68179546680552ca72c5c4bc","project":"TESTPROJ11","organisation":"TESTORG11","infrastructure":"TESTINFRA11","installation":"TESTINSTA11","resource":"TESTRES11","unit_of_access":null},
-        {"id":"68179546680552ca72c5c4bd","project":"TESTPROJ12","organisation":"TESTORG12","infrastructure":"TESTINFRA12","installation":"TESTINSTA12","resource":"TESTRES12","unit_of_access":null}
-    ],"links":[]}"""
-    GET_INSTALLATION_TEST_RESPONSE = """{"id": "68179546f1a5b48f0c854353", "project": "TESTPROJ01", "organisation": "TESTORG01", "infrastructure": "TESTINFRA01", "installation": "TESTINSTA01", "resource": "TESTRES01", "unit_of_access": null}"""
+    LIST_INSTALLATIONS_RESPONSE1 = (
+        """{"size_of_page":10,"number_of_page":1,"total_elements":12,"total_pages":2,"content":["""
+        """{"id":"68179546f1a5b48f0c854353","project":"TESTPROJ01","organisation":"TESTORG01","infrastructure":"""
+        """"TESTINFRA01","installation":"TESTINSTA01","resource":"TESTRES01","unit_of_access":null},"""
+        """{"id":"681795464c2922e4367fe1c4","project":"TESTPROJ02","organisation":"TESTORG02","infrastructure":"""
+        """"TESTINFRA02","installation":"TESTINSTA02","resource":"TESTRES02","unit_of_access":null},"""
+        """{"id":"681795463c792bf6c23aa741","project":"TESTPROJ03","organisation":"TESTORG03","infrastructure":"""
+        """"TESTINFRA03","installation":"TESTINSTA03","resource":"TESTRES03","unit_of_access":null},"""
+        """{"id":"681795463ae9de407c8073da","project":"TESTPROJ04","organisation":"TESTORG04","infrastructure":"""
+        """"TESTINFRA04","installation":"TESTINSTA04","resource":"TESTRES04","unit_of_access":null},"""
+        """{"id":"681795460e9b55f38d982f77","project":"TESTPROJ05","organisation":"TESTORG05","infrastructure":"""
+        """"TESTINFRA05","installation":"TESTINSTA05","resource":"TESTRES05","unit_of_access":null},"""
+        """{"id":"681795468c189cee4e182e7e","project":"TESTPROJ06","organisation":"TESTORG06","infrastructure":"""
+        """"TESTINFRA06","installation":"TESTINSTA06","resource":"TESTRES06","unit_of_access":null},"""
+        """{"id":"68179546dce2f040d31e0129","project":"TESTPROJ07","organisation":"TESTORG07","infrastructure":"""
+        """"TESTINFRA07","installation":"TESTINSTA07","resource":"TESTRES07","unit_of_access":null},"""
+        """{"id":"68179546e21a7a5849d09fb3","project":"TESTPROJ08","organisation":"TESTORG08","infrastructure":"""
+        """"TESTINFRA08","installation":"TESTINSTA08","resource":"TESTRES08","unit_of_access":null},"""
+        """{"id":"68179546f9116f197e3df2a0","project":"TESTPROJ09","organisation":"TESTORG09","infrastructure":"""
+        """"TESTINFRA09","installation":"TESTINSTA09","resource":"TESTRES09","unit_of_access":null},"""
+        """{"id":"68179546680552ca72c5c4bb","project":"TESTPROJ10","organisation":"TESTORG10","infrastructure":"""
+        """"TESTINFRA10","installation":"TESTINSTA10","resource":"TESTRES10","unit_of_access":null}"""
+        """],"links":[]}"""
+    )
+
+    LIST_INSTALLATIONS_RESPONSE2 = (
+        """{"size_of_page":10,"number_of_page":2,"total_elements":12,"total_pages":2,"content":[{"id":"""
+        """"68179546680552ca72c5c4bc","project":"TESTPROJ11","organisation":"TESTORG11","infrastructure":"""
+        """"TESTINFRA11","installation":"TESTINSTA11","resource":"TESTRES11","unit_of_access":null},{"id":"""
+        """"68179546680552ca72c5c4bd","project":"TESTPROJ12","organisation":"TESTORG12","infrastructure":"""
+        """"TESTINFRA12","installation":"TESTINSTA12","resource":"TESTRES12","unit_of_access":null}],"links":[]}"""
+    )
+
+    GET_INSTALLATION_TEST_RESPONSE = (
+        """{"id": "68179546f1a5b48f0c854353", "project": "TESTPROJ01", "organisation":"""
+        """ "TESTORG01", "infrastructure": "TESTINFRA01", "installation": "TESTINSTA01", "resource": "TESTRES01","""
+        """ "unit_of_access": null}"""
+    )
 
     list_installations_urlmatch1 = dict(
         netloc="localhost",
@@ -151,8 +195,10 @@ class InstallationMocks(object):
         assert request.method == "GET"
         return response(200, self.LIST_INSTALLATIONS_RESPONSE1, None, None, 5, request)
 
+
 class InstallationMetricMocks(object):
-    LIST_TEST_INSTALLATION_METRIC_LIST_RESPONSE = """{"size_of_page":10,"number_of_page":1,"total_elements":1,"total_pages":1,"content":[
+    LIST_TEST_INSTALLATION_METRIC_LIST_RESPONSE = (
+        """{"size_of_page":10,"number_of_page":1,"total_elements":1,"total_pages":1,"content":[
         {"id":"681bc483371ad01d931461bf",
         "time_period_start":"2024-01-01T03:43:40Z",
         "time_period_end":"2024-01-01T09:20:37Z",
@@ -172,13 +218,14 @@ class InstallationMetricMocks(object):
             "creator_id":"4e0391ea-7b42-4b0a-a1b4-a70dd046df81@example.org"
         }}
     ],"links":[]}"""
+    )
 
     GET_TEST_INSTALLATION_METRIC_RESPONSE = """{
-        "metric_id": "681bc483371ad01d931461bf", 
+        "metric_id": "681bc483371ad01d931461bf",
         "metric_definition_id": "678f89694665a309e8a6c9b2",
         "time_period_start": "2024-01-01T03:43:40Z",
         "time_period_end": "2024-01-01T09:20:37Z",
-        "value": 66.0336, 
+        "value": 66.0336,
         "user_id": "0123456789abcdef"
     }"""
 
@@ -251,8 +298,10 @@ class InstallationMetricMocks(object):
             201, body, None, None, 5, request
         )
 
+
 class ProjectMetricMocks(object):
-    LIST_TEST_PROJECT_METRIC_LIST_RESPONSE = """{"size_of_page":10,"number_of_page":1,"total_elements":1,"total_pages":1,"content":[
+    LIST_TEST_PROJECT_METRIC_LIST_RESPONSE = (
+        """{"size_of_page":10,"number_of_page":1,"total_elements":1,"total_pages":1,"content":[
    {
       "id": "67ed2aaae8af660056233998",
       "time_period_start": "2024-01-01T03:43:40Z",
@@ -274,6 +323,7 @@ class ProjectMetricMocks(object):
       }
     }
     ],"links":[]}"""
+    )
 
     list_test_project_metrics_urlmatch = dict(
         netloc="localhost",
@@ -299,7 +349,8 @@ class ProjectMetricMocks(object):
 
 
 class ProjectProviderMetricMocks(object):
-    LIST_TEST_PROJECT_PROVIDER_METRIC_LIST_RESPONSE = """{"size_of_page":10,"number_of_page":1,"total_elements":1,"total_pages":1,"content":[
+    LIST_TEST_PROJECT_PROVIDER_METRIC_LIST_RESPONSE = (
+        """{"size_of_page":10,"number_of_page":1,"total_elements":1,"total_pages":1,"content":[
    {
       "id": "67ed2aaae8af660056233998",
       "time_period_start": "2024-01-01T03:43:40Z",
@@ -321,6 +372,7 @@ class ProjectProviderMetricMocks(object):
       }
     }
     ],"links":[]}"""
+    )
 
     list_test_project_provider_metrics_urlmatch = dict(
         netloc="localhost",

--- a/tests/test_installations.py
+++ b/tests/test_installations.py
@@ -1,7 +1,10 @@
 import unittest
-from .accmocks import InstallationMocks, ProjectMocks, ProviderMocks
+
 from httmock import HTTMock
-from pymod import ArgoAccountingService, Installations
+
+from pymod import ArgoAccountingService
+
+from .accmocks import InstallationMocks, ProjectMocks, ProviderMocks
 
 
 class TestInstallations(unittest.TestCase):
@@ -101,7 +104,8 @@ class TestInstallations(unittest.TestCase):
     def testGetTestProjectProviderInstallationByIndex(self):
         """Test JSON representation of an installation"""
         with (
-                HTTMock(self.InstallationMocks.get_test_project_provider_installations_mock)
+                HTTMock(self.ProjectMocks.get_project_test_mock),
+                HTTMock(self.InstallationMocks.get_test_project_provider_installations_mock),
         ):
             p = self.acc.projects["TESTPROJ01"].providers["TESTPROV01"]
             i = p.installations[0]
@@ -116,6 +120,7 @@ class TestInstallations(unittest.TestCase):
     def testGetTestProjectProvidersInstallationJson(self):
         """Test JSON representation of an installation"""
         with (
+                HTTMock(self.ProjectMocks.get_project_test_mock),
                 HTTMock(self.InstallationMocks.get_test_project_provider_installations_mock)
         ):
             p = self.acc.projects["TESTPROJ01"].providers["TESTPROV01"]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,8 +1,13 @@
 import unittest
-from .accmocks import InstallationMocks, InstallationMetricMocks, ProjectMocks, ProjectMetricMocks, ProjectProviderMetricMocks
-from httmock import urlmatch, HTTMock, response
+
+from httmock import HTTMock
+
 from pymod import ArgoAccountingService, InstallationMetric
-import logging
+
+from .accmocks import (InstallationMetricMocks, InstallationMocks,
+                       ProjectMetricMocks, ProjectMocks,
+                       ProjectProviderMetricMocks)
+
 
 class TestMetrics(unittest.TestCase):
     def setUp(self):
@@ -27,6 +32,7 @@ class TestMetrics(unittest.TestCase):
     def testGetTestInstallationMetricByID(self):
         with HTTMock(
             self.InstallationMetricMocks.get_test_installation_metric_item_mock,
+            self.InstallationMocks.get_installation_test_mock,
         ):
             metric = self.acc.installations["68179546f1a5b48f0c854353"].metrics[
                 "681bc483371ad01d931461bf"
@@ -41,6 +47,7 @@ class TestMetrics(unittest.TestCase):
         with HTTMock(
             self.InstallationMetricMocks.get_test_installation_metric_item_mock,
             self.InstallationMetricMocks.get_test_installation_metric_list_mock,
+            self.InstallationMocks.get_installation_test_mock,
         ):
             metric = self.acc.installations["68179546f1a5b48f0c854353"].metrics[0]
             self.assertEqual(metric.id, "681bc483371ad01d931461bf")
@@ -52,6 +59,7 @@ class TestMetrics(unittest.TestCase):
     def testGetTestInstallationMetricJSON(self):
         with HTTMock(
             self.InstallationMetricMocks.get_test_installation_metric_item_mock,
+            self.InstallationMocks.get_installation_test_mock,
         ):
             metric = self.acc.installations["68179546f1a5b48f0c854353"].metrics[
                 "681bc483371ad01d931461bf"
@@ -128,7 +136,11 @@ class TestMetrics(unittest.TestCase):
             self.InstallationMetricMocks.post_installation_test_metric_mock,
         ):
             installation = self.acc.installations["68179546f1a5b48f0c854353"]
-            m = """{"metric_definition_id": "678f89694665a309e8a6c9b2", "time_period_start": "2024-01-01T03:43:40Z", "time_period_end": "2024-01-01T09:20:37Z", "value": 66.0336, "group_id": "3f5fc61f3e3af93b", "user_id": "9936cb22d3c26a34"}"""
+            m = (
+                """{"metric_definition_id": "678f89694665a309e8a6c9b2", "time_period_start": "2024-01-01T03:43:40Z","""
+                """ "time_period_end": "2024-01-01T09:20:37Z", "value": 66.0336, "group_id": "3f5fc61f3e3af93b","""
+                """ "user_id": "9936cb22d3c26a34"}"""
+            )
             ret = installation.metrics.add(m)
             self.assertEqual(ret.metric_definition_id, "678f89694665a309e8a6c9b2")
             self.assertEqual(ret.time_period_start, "2024-01-01T03:43:40Z")

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,7 +1,10 @@
 import unittest
-from .accmocks import ProjectMocks
+
 from httmock import HTTMock
-from pymod import ArgoAccountingService, Projects
+
+from pymod import ArgoAccountingService
+
+from .accmocks import ProjectMocks
 
 
 class TestProjects(unittest.TestCase):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,7 +1,10 @@
 import unittest
-from .accmocks import ProviderMocks
+
 from httmock import HTTMock
-from pymod import ArgoAccountingService, Providers
+
+from pymod import ArgoAccountingService
+
+from .accmocks import ProviderMocks
 
 
 class TestProviders(unittest.TestCase):


### PR DESCRIPTION
- added bandit and mypy config files
- fixed import statement ordering
- handled unused imports
- fixed max line length
- changed mixedCase to snake_case where applicable
- removed class attributes where not need to avoid issues with instance mutations
- added basic missing class docstrings