### PR TITLE
Change return projects call due to change in the ACC service

### DIFF
--- a/pymod/httprequests.py
+++ b/pymod/httprequests.py
@@ -43,7 +43,7 @@ class HttpRequests(object):
             ],
             "project_list": [
                 "get",
-                "https://{0}/accounting-system/projects",
+                "https://{0}/accounting-system/admin/projects",
             ],
             "project_entry": [
                 "get",

--- a/tests/accmocks.py
+++ b/tests/accmocks.py
@@ -64,7 +64,7 @@ class ProjectMocks(object):
 
     list_projects_urlmatch = dict(
         netloc="localhost",
-        path="/accounting-system/projects",
+        path="/accounting-system/admin/projects",
         method="GET",
         query="page=1",
     )
@@ -77,7 +77,7 @@ class ProjectMocks(object):
 
     @urlmatch(**list_projects_urlmatch)
     def list_projects_mock(self, url, request):
-        assert url.path == "/accounting-system/projects"
+        assert url.path == "/accounting-system/admin/projects"
         assert request.method == "GET"
         return response(200, self.LIST_PROJECTS_RESPONSE, None, None, 5, request)
 


### PR DESCRIPTION
Changed the return projects call to align with the updated ACC service API. This ensures compatibility with the latest response format and prevents potential runtime errors due to the service change.